### PR TITLE
비츠

### DIFF
--- a/elk-dev-p1/beats/Dockerfile
+++ b/elk-dev-p1/beats/Dockerfile
@@ -1,0 +1,15 @@
+FROM docker.elastic.co/beats/filebeat:7.17.1
+
+COPY filebeat/filebeat.yml /usr/share/filebeat/filebeat.yml
+COPY filebeat/modules.d /usr/share/filebeat/modules.d
+RUN filebeat modules enable logstash
+
+USER root
+RUN chown root:filebeat /usr/share/filebeat/filebeat.yml
+
+USER filebeat
+CMD ["filebeat", "-e", "-c", "/usr/share/filebeat/filebeat.yml"]
+
+# 도커 파일 명령어
+# docker build -t filebeat_docker_image .
+# docker run --name docker_container_name --network docker-compose_elk-network -d logstash_docker_image

--- a/elk-dev-p1/beats/beats.md
+++ b/elk-dev-p1/beats/beats.md
@@ -1,0 +1,87 @@
+# Beats
+
+### 요약
+비츠(Beats)는 Logstash와 달리 하나의 출력(output)만을 가질 수 있는 가볍고 사용하기 쉬운 데이터 수집기입니다.
+
+### 소개
+- Beats는 다양한 시스템의 이벤트를 수집하여 Logstash나 Elasticsearch로 전송하는 가볍고 간편한 데이터 수집 도구입니다. 
+- 설정이 간편하며, 별도의 데이터 가공을 위한 프로그래밍 작업이 필요하지 않습니다. 
+- 다양한 비트(Beats)들이 존재하며, 각각 특정 목적에 최적화되어 있습니다.
+- **주요 비트(Beats) 종류**:
+  - **파일비트(Filebeat)**: 로그 파일을 실시간으로 수집
+  - **메트릭비트(Metricbeat)**: 시스템 및 서비스의 메트릭 수집
+  - **패킷비트(Packetbeat)**: 네트워크 데이터 수집
+
+### Logstash와의 비교
+
+- **Logstash**:
+  - 다양한 플러그인을 지원하여 범용성이 높지만, 상대적으로 무겁습니다.
+  - 대규모 이벤트 가공에 적합하며, 복잡한 데이터 처리 작업을 수행할 수 있습니다.
+
+- **Beats**:
+  - 범용성을 포기하고 특정 목적의 데이터 수집에 최적화되어 있어 가볍고 빠릅니다.
+  - 애플리케이션 성능에 미치는 영향을 최소화하면서 필요한 이벤트를 수집합니다.
+  - 기본적인 이벤트 가공을 일부 지원합니다.
+
+### Beats의 활용
+
+- **데이터 흐름**:
+  - Beats에서 수집한 데이터 → Elasticsearch로 전송
+  - Beats에서 수집한 데이터 → Logstash로 전송 → Elasticsearch로 전송
+
+### 파일비트(Filebeat) 아키텍처
+
+Filebeat는 로그 파일을 실시간으로 읽어들이며, 구성 요소는 다음과 같습니다:
+
+- **입력(Input)**: 수집할 파일의 경로를 설정합니다.
+- **하베스터(Harvester)**: 지정된 파일을 읽고 데이터를 수집합니다. 파일이 변경될 때마다 데이터를 지속적으로 읽습니다.
+- **스펄러(Spooler)**: 수집한 데이터를 Elasticsearch나 Logstash로 전송합니다.
+
+Filebeat는 파일의 새로운 내용을 모니터링하고, 새로운 파일이 발견되면 하베스터를 생성하여 데이터를 읽어들입니다.
+
+### 입력(Input) 타입
+
+- **log**: 일반적인 로그 파일 수집
+- **container**: 컨테이너 로그 수집
+- **s3**: AWS S3에서 로그 수집
+- **kafka**: Kafka에서 데이터 수집
+
+### 출력(Output) 타입
+
+- **elasticsearch**: 데이터를 Elasticsearch로 전송
+- **logstash**: 데이터를 Logstash로 전송
+- **kafka**: 데이터를 Kafka로 전송
+- **console**: 데이터를 콘솔에 출력
+
+### filebeat.yml 설정
+
+- **ignore_older**: 설정한 시간 이전의 로그는 무시
+
+```yaml
+ignore_older: 2h
+```
+
+- **간단한 정제 작업**: 포함/제외할 로그 패턴 설정
+
+```yaml
+include_lines: ['^ERR', '^WARN']
+exclude_lines: ['^DBG']
+exclude_files: ['\.gz$']
+```
+
+- **멀티라인 처리**: 여러 줄에 걸친 로그를 하나로 처리
+
+```yaml
+multiline.pattern: '^[[:space:]]'  
+multiline.negate: false
+multiline.match: after
+```
+
+### 모듈
+
+Beats는 다양한 모듈을 통해 특정 데이터 소스를 쉽게 수집할 수 있습니다:
+
+- **aws**: AWS 서비스 로그 수집
+- **cef**: Common Event Format 로그 수집
+- **elasticsearch**: Elasticsearch 로그 수집
+- **logstash**: Logstash 로그 수집

--- a/elk-dev-p1/beats/filebeat/filebeat.yml
+++ b/elk-dev-p1/beats/filebeat/filebeat.yml
@@ -1,0 +1,19 @@
+filebeat.inputs:
+  - type: log
+    enabled: true
+    paths:
+      - /var/log/*.log
+
+output.elasticsearch:
+  hosts: ["elasticsearch:9200"]
+
+setup.kibana:
+  host: "kibana:5601"
+
+filebeat.config.modules:
+  enabled: true
+  path: /usr/share/filebeat/modules.d/*.yml
+
+monitoring.enabled: true
+monitoring.elasticsearch:
+  hosts: ["elasticsearch:9200"]

--- a/elk-dev-p1/beats/filebeat/modules.d/logstash.yml
+++ b/elk-dev-p1/beats/filebeat/modules.d/logstash.yml
@@ -1,0 +1,17 @@
+# Module: logstash
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/7.17/filebeat-module-logstash.html
+
+- module: logstash
+  # logs
+  log:
+    enabled: true
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+  # Slow logs
+  slowlog:
+    enabled: true
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:


### PR DESCRIPTION
맥의 경우 qemu 기반 가상화로 운영되어 /var/lib/docker 접근을 못하다보니 볼륨 데이터를 확인을 할 수 없었습니다.
여러컨테이너를 묶어서 테스트해야하는 상황에서 docker-compose 구성시 편리할 수 있겠다는 생각이 들었습니다.
도커 특성상 filebeat 모듈 활성화 및 기타 기능을 끄고 키기위한 상황에서의 테스트가 불편해 테스트 과정에서는 ec2와 같은 인스턴스 위에 설치하거나 특정 운영체제 컨테이너 내부에 비츠를 설치하는 방식이 더 적절하지않을까라는 생각을 했습니다.

책에서 가이드하는 버전과 달라서인지 비츠 키바나 모니터링시 비츠 컨테이너에서 metric.go 에러 발생
logstash 모듈 활성화하는 법만 테스트하고 비트-> 로그스태시 전송이 주 목적인데 역으로는 불필요하다는 생각이 들어 모듈 활성화 설정만 해둔채 테스트 제외